### PR TITLE
fix: update the csrf trusted origins

### DIFF
--- a/brightIDfaucet/settings.py
+++ b/brightIDfaucet/settings.py
@@ -305,3 +305,13 @@ REST_FRAMEWORK = {
     ),
 }
 CELERY_BROKER_URL = REDIS_URL
+
+CSRF_TRUSTED_ORIGINS = [
+    "https://unitap-front.vercel.app",
+    "https://unitap.app",
+    "https://www.unitap.app",
+    "https://dashboard.unitap.app",
+    "https://bright.cafepay.app",
+    "https://api.unitap.app",
+    "https://stage.unitap.app",
+]


### PR DESCRIPTION
## Summary by Sourcery

Update security settings to include new trusted origins for CSRF protection

Enhancements:
- Add Unitap front-end, dashboard, API, and staging domains to CSRF_TRUSTED_ORIGINS
- Add Bright Cafepay domain to CSRF_TRUSTED_ORIGINS